### PR TITLE
Increase story budgets and auto-fetch Unicode fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ GradReader is a Streamlit application that generates graded reading stories, aud
 - Produce individual PDFs per story or a single combined PDF with a table of contents.
 - Download a ZIP archive containing PDFs, MP3 audio files, and a manifest.
 - Optional bilingual glossary aligned to the reader's native language.
-- Unicode-friendly typography using bundled Noto fonts for global language support.
+- Paragraph-by-paragraph reading support with phonetic guides, translations, and grammar notes.
+- Unicode-friendly typography with automatic discovery (and optional on-demand download) of Noto/Source Han fonts for global language support.
 - Streamlit session state keeps generated artefacts available across reruns.
 
 ## Getting Started
@@ -54,7 +55,7 @@ The sidebar lets you pick separate models for text generation (`model_text`) and
 
 ### Fonts and Licensing
 
-The repository bundles Noto Sans and Noto Serif under the [SIL Open Font License](https://scripts.sil.org/OFL). These ensure consistent rendering of multi-script stories.
+When Unicode-capable fonts are missing, the app now attempts to download Noto Sans/Serif CJK fonts into `assets/fonts` automatically (internet access required). You can also place your own fonts in that directory or install them system-wide, and GradReader will discover them on the next run. This ensures PDFs render Chinese, Japanese, Korean, and other non-Latin scripts without fallback artifacts. All suggested fonts are distributed under the [SIL Open Font License](https://scripts.sil.org/OFL).
 
 ### Troubleshooting
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -304,12 +304,55 @@ def main() -> None:
                 if caption_parts:
                     st.caption(" • ".join(caption_parts))
 
-                st.write(story["body"])
+                summary = story.get("summary")
+                if summary:
+                    st.info(summary)
+
+                reading_sections = story.get("reading_sections") or []
+                if reading_sections:
+                    for section_idx, section in enumerate(reading_sections, start=1):
+                        original = section.get("original")
+                        phonetics = section.get("phonetics")
+                        translation = section.get("translation")
+                        st.markdown(f"**Paragraph {section_idx}:**")
+                        if original:
+                            st.markdown(f"- *Original*: {original}")
+                        if phonetics:
+                            st.markdown(f"- *Pronunciation*: {phonetics}")
+                        if translation:
+                            st.markdown(f"- *Translation*: {translation}")
+                        st.markdown("")
+                else:
+                    st.write(story.get("body", ""))
+
+                full_translation = story.get("translation")
+                if full_translation:
+                    with st.expander("View full story translation"):
+                        st.write(full_translation)
+
                 glossary = story.get("glossary") or []
                 if params_state.get("include_glossary") and glossary:
                     st.markdown("**Glossary**")
                     for entry in glossary:
                         st.write(f"- {entry['term']}: {entry['definition']}")
+
+                grammar_notes = story.get("grammar_notes") or []
+                if grammar_notes:
+                    st.markdown("**Grammar notes**")
+                    for note in grammar_notes:
+                        st.write(f"- {note}")
+
+                practice_ideas = story.get("practice_ideas") or []
+                if practice_ideas:
+                    st.markdown("**Practice ideas**")
+                    for idea in practice_ideas:
+                        st.write(f"- {idea}")
+
+                extra_notes = story.get("extra_notes") or []
+                if extra_notes:
+                    st.markdown("**Strategy & culture notes**")
+                    for note in extra_notes:
+                        st.write(f"- {note}")
 
                 audio_bytes = st.session_state["audio"].get(idx)
                 if audio_bytes:

--- a/utils/ai.py
+++ b/utils/ai.py
@@ -54,17 +54,29 @@ def build_story_prompt(params: Dict[str, Any]) -> str:
     topic_text = "\n- ".join(topics) if topics else "None specified"
 
     glossary_instruction = (
-        "Include a short glossary of 5-8 important words translated into the "
+        "Include a short glossary of 6-10 important words translated into the "
         f"reader's native language ({params.get('native_language')})."
         if params.get("include_glossary")
-        else "Do not include a glossary."
+        else "Do not include a glossary section."
     )
 
     length_instruction = {
-        "short": "about 150-250 words",
-        "medium": "about 300-450 words",
-        "long": "about 500-700 words",
-    }.get(params.get("story_length", "medium"), "about 300-450 words")
+        "short": "around 280-380 words",
+        "medium": "around 600-800 words (aim for a full A4 page when typeset)",
+        "long": "around 800-1000 words",
+    }.get(params.get("story_length", "medium"), "around 600-800 words")
+
+    paragraph_instruction = {
+        "short": "6-7",
+        "medium": "8-9",
+        "long": "9-11",
+    }.get(params.get("story_length", "medium"), "8-9")
+
+    phonetics_instruction = (
+        "Use the standard phonetic guide for the learning language (e.g. Pinyin for Chinese, "
+        "Romaji for Japanese, Revised Romanization for Korean). If the language already uses "
+        "the Latin alphabet, provide syllable-level chunking with stress hints instead."
+    )
 
     storyline_goal = params.get("story_goal", "Engage the reader with a positive tone.")
 
@@ -75,37 +87,115 @@ Write a story in {params.get('learning_language')} that matches the following co
 - Reader's native language: {params.get('native_language')}
 - Story length: {length_instruction}
 - Topics: {topic_text}
-- Number of paragraphs: 4-6 with short sentences for lower levels.
+- Number of story paragraphs: {paragraph_instruction} with clear transitions.
 - Maintain cultural neutrality and avoid idioms or slang unless it is level-appropriate.
 - Provide a concise and descriptive title.
 - Ensure the language strictly uses {params.get('learning_language')} without switching languages.
 - {storyline_goal}
 - Keep paragraphs short (max 4 sentences) and add line breaks between paragraphs.
-{glossary_instruction}
+- Provide paragraph-by-paragraph support materials described below.
+- {glossary_instruction}
+- Add 2-3 grammar or usage notes that highlight level-appropriate structures from the story.
+- Add 2-3 suggested follow-up practice activities such as comprehension prompts or extension tasks.
 
 Respond ONLY in valid JSON with the following structure:
 {{
   "title": "...",
-  "story": "Story body in {params.get('learning_language')} with paragraph breaks",
+  "summary": "1-2 sentence overview in {params.get('native_language')} describing the plot and learning focus.",
+  "reading_sections": [
+    {{
+      "original": "Paragraph of the story in {params.get('learning_language')}",
+      "phonetics": "Matching paragraph rendered in phonetics ({phonetics_instruction})",
+      "translation": "Paragraph translated to {params.get('native_language')}"
+    }}
+  ],
   "glossary": [
     {{"term": "", "definition": "translation in {params.get('native_language')}"}}
-  ]  // optional, omit or use [] if not requested
+  ],
+  "grammar_notes": ["Brief bullet explaining a grammar point with examples"],
+  "practice_ideas": ["Suggestion for further practice or reflection question"],
+  "culture_or_strategy_notes": ["Optional learning strategies or cultural insights that support the graded reader"]
 }}
 """
 
     return prompt.strip()
 
 
+def _repair_json_payload(payload: str) -> Dict[str, Any]:
+    """Attempt to coerce an LLM payload into valid JSON.
+
+    The OpenAI ``response_format`` safeguard generally keeps responses valid,
+    but occasionally the model can still prepend/appended stray text (for
+    example when it emits warnings). We take a forgiving approach by slicing
+    out the innermost JSON object and retrying the parse before raising an
+    error back to the caller. The original payload is preserved for debugging
+    via the chained exception message.
+    """
+
+    text = (payload or "").strip()
+
+    # Fast path – most responses are already valid JSON.
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Attempt to salvage the first JSON object if the model added narration
+    # such as "Here is the story" before the structured payload.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        candidate = text[start : end + 1]
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+
+    raise ValueError("Model response was not valid JSON.")
+
+
 def _parse_story_payload(payload: str) -> Dict[str, Any]:
     """Parse a JSON payload returned by the model into a dictionary."""
 
     try:
-        data = json.loads(payload)
-    except json.JSONDecodeError as exc:
-        raise ValueError("Model response was not valid JSON.") from exc
+        data = _repair_json_payload(payload)
+    except ValueError as exc:
+        # Surface a shortened preview of the problematic payload to help the
+        # user troubleshoot without overwhelming the UI.
+        preview = (payload or "").strip().splitlines()
+        preview_text = " ".join(preview)[:280]
+        raise ValueError(
+            f"Model response was not valid JSON. Received: {preview_text}"
+        ) from exc
 
     title = data.get("title", "Untitled Story").strip()
-    body = data.get("story", "").strip()
+    summary = str(data.get("summary", "")).strip()
+
+    sections_raw = data.get("reading_sections") or []
+    reading_sections: List[Dict[str, str]] = []
+    body_paragraphs: List[str] = []
+    translation_paragraphs: List[str] = []
+
+    if isinstance(sections_raw, list):
+        for section in sections_raw:
+            if not isinstance(section, dict):
+                continue
+            original = str(section.get("original", "")).strip()
+            phonetics = str(section.get("phonetics", "")).strip()
+            translation = str(section.get("translation", "")).strip()
+            if not original:
+                continue
+            reading_sections.append(
+                {
+                    "original": original,
+                    "phonetics": phonetics,
+                    "translation": translation,
+                }
+            )
+            body_paragraphs.append(original)
+            if translation:
+                translation_paragraphs.append(translation)
+
     glossary = data.get("glossary") or []
 
     # Ensure glossary is a list of dictionaries with required keys
@@ -119,7 +209,44 @@ def _parse_story_payload(payload: str) -> Dict[str, Any]:
             if term and definition:
                 cleaned_glossary.append({"term": term, "definition": definition})
 
-    return {"title": title, "body": body, "glossary": cleaned_glossary}
+    grammar_notes_raw = data.get("grammar_notes") or []
+    grammar_notes: List[str] = []
+    if isinstance(grammar_notes_raw, list):
+        for note in grammar_notes_raw:
+            note_text = str(note).strip()
+            if note_text:
+                grammar_notes.append(note_text)
+
+    practice_raw = data.get("practice_ideas") or []
+    practice_ideas: List[str] = []
+    if isinstance(practice_raw, list):
+        for idea in practice_raw:
+            idea_text = str(idea).strip()
+            if idea_text:
+                practice_ideas.append(idea_text)
+
+    extras_raw = data.get("culture_or_strategy_notes") or []
+    extra_notes: List[str] = []
+    if isinstance(extras_raw, list):
+        for entry in extras_raw:
+            entry_text = str(entry).strip()
+            if entry_text:
+                extra_notes.append(entry_text)
+
+    body = "\n\n".join(body_paragraphs).strip()
+    full_translation = "\n\n".join(translation_paragraphs).strip()
+
+    return {
+        "title": title,
+        "summary": summary,
+        "body": body,
+        "reading_sections": reading_sections,
+        "translation": full_translation,
+        "glossary": cleaned_glossary,
+        "grammar_notes": grammar_notes,
+        "practice_ideas": practice_ideas,
+        "extra_notes": extra_notes,
+    }
 
 
 def generate_story(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -150,30 +277,99 @@ def generate_story(params: Dict[str, Any]) -> Dict[str, Any]:
     temperature = float(params.get("temperature", 0.7))
     top_p = float(params.get("top_p", 0.95))
 
-    response = client.chat.completions.create(
-        model=params.get("model_text", "gpt-4o-mini"),
-        temperature=temperature,
-        top_p=top_p,
-        max_tokens=int(params.get("max_tokens", 1200)),
-        response_format={"type": "json_object"},
-        messages=[
-            {
-                "role": "system",
-                "content": (
-                    "You are a supportive language tutor and expert storyteller "
-                    "who writes engaging graded readers."
-                ),
-            },
-            {"role": "user", "content": prompt},
-        ],
-    )
+    def _suggested_token_budget() -> int:
+        story_length = str(params.get("story_length", "medium")).lower()
+        base_budget = {
+            # Readers now include phonetics, translations, and scaffolding for
+            # every paragraph, which triples the footprint compared to the
+            # original story text. Start with more generous budgets so the
+            # model has room to complete the JSON payload.
+            "short": 3200,
+            "medium": 4800,
+            "long": 6000,
+        }.get(story_length, 4800)
 
-    content = response.choices[0].message.content
-    if not content:
-        raise ValueError("No content returned by the model.")
+        # Longer responses are needed when auxiliary study aids are included.
+        extras = 600 if params.get("include_glossary") else 300
+        # Grammar notes, practice ideas, and cultural strategies are always requested.
+        extras += 650
 
-    story = _parse_story_payload(content)
-    return story
+        # Cap the budget to stay within the model's context window while ensuring
+        # we request enough space for well-formed JSON.
+        return max(2000, min(base_budget + extras, 7200))
+
+    max_tokens = int(params.get("max_tokens") or _suggested_token_budget())
+
+    attempt = 0
+    max_attempts = 5
+    last_error: Optional[Exception] = None
+    while attempt < max_attempts:
+        response = client.chat.completions.create(
+            model=params.get("model_text", "gpt-4o-mini"),
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            response_format={"type": "json_object"},
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a supportive language tutor and expert storyteller "
+                        "who writes engaging graded readers."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+        )
+
+        choice = response.choices[0]
+        finish_reason = getattr(choice, "finish_reason", "stop")
+        if finish_reason and finish_reason != "stop":
+            if finish_reason == "length" and attempt + 1 < max_attempts:
+                max_tokens = min(max_tokens + 1400, 7200)
+                attempt += 1
+                last_error = ValueError(
+                    "Model stopped early because the response hit the token limit; retrying with a larger budget."
+                )
+                continue
+
+            raise ValueError(
+                "Story generation halted early. Increase the max tokens setting or simplify the prompt."
+            )
+
+        content = choice.message.content if choice.message else None
+        if not content:
+            raise ValueError("No content returned by the model.")
+
+        try:
+            story = _parse_story_payload(content)
+            return story
+        except ValueError as exc:
+            last_error = exc
+
+            # If the payload is obviously truncated (e.g. missing a closing brace),
+            # treat it like a length issue and substantially expand the token
+            # budget before retrying.
+            stripped = (content or "").strip()
+            truncated = bool(stripped) and (
+                not stripped.endswith("}")
+                or stripped.count("{") > stripped.count("}")
+                or stripped.endswith("\"")
+            )
+
+            if attempt + 1 < max_attempts:
+                if truncated:
+                    max_tokens = min(max_tokens + 1600, 7200)
+                else:
+                    max_tokens = min(int(max_tokens * 1.4), 7200)
+                attempt += 1
+                continue
+            raise
+
+    if last_error:
+        raise last_error
+
+    raise ValueError("Story generation failed for an unknown reason.")
 
 
 __all__ = [

--- a/utils/pdf.py
+++ b/utils/pdf.py
@@ -1,8 +1,11 @@
 """PDF generation helpers for graded reader stories."""
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, Iterable, List, Sequence
+
+from urllib.request import urlopen
 
 import streamlit as st
 from fpdf import FPDF
@@ -10,6 +13,54 @@ from fpdf.errors import FPDFException
 
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets" / "fonts"
+ASSETS_DIR.mkdir(parents=True, exist_ok=True)
+
+FONT_SEARCH_PATHS = [
+    ASSETS_DIR,
+    Path.home() / "fonts",
+    Path.home() / ".fonts",
+    Path("/usr/share/fonts"),
+    Path("/usr/local/share/fonts"),
+    Path("/Library/Fonts"),
+    Path("/System/Library/Fonts"),
+    Path("C:/Windows/Fonts"),
+]
+
+FONT_CANDIDATES = {
+    "sans": [
+        "NotoSansCJKsc-Regular.otf",
+        "NotoSansCJK-Regular.ttc",
+        "NotoSansSC-Regular.otf",
+        "SourceHanSansSC-Regular.otf",
+        "NotoSans-Regular.ttf",
+        "DejaVuSans.ttf",
+    ],
+    "serif": [
+        "NotoSerifCJKsc-Regular.otf",
+        "SourceHanSerifSC-Regular.otf",
+        "NotoSerif-Regular.ttf",
+        "DejaVuSerif.ttf",
+    ],
+}
+
+FONT_DOWNLOADS: Dict[str, Iterable[str]] = {
+    "sans": (
+        # Simplified Chinese Sans
+        "https://github.com/googlefonts/noto-cjk/raw/refs/heads/main/Sans/OTF/"
+        "SimplifiedChinese/NotoSansSC-Regular.otf",
+        # General-purpose Unicode sans as a fallback
+        "https://github.com/googlefonts/noto-fonts/raw/refs/heads/main/unhinted/"
+        "otf/NotoSans/NotoSans-Regular.otf",
+    ),
+    "serif": (
+        # Simplified Chinese Serif
+        "https://github.com/googlefonts/noto-cjk/raw/refs/heads/main/Serif/OTF/"
+        "SimplifiedChinese/NotoSerifSC-Regular.otf",
+        # General-purpose Unicode serif fallback
+        "https://github.com/googlefonts/noto-fonts/raw/refs/heads/main/unhinted/"
+        "otf/NotoSerif/NotoSerif-Regular.otf",
+    ),
+}
 
 
 class StoryPDF(FPDF):
@@ -138,31 +189,77 @@ class StoryPDF(FPDF):
 def load_fonts() -> Dict[str, str]:
     """Return absolute paths to bundled Noto fonts."""
 
-    fonts = {
-        "sans": str(ASSETS_DIR / "NotoSans-Regular.ttf"),
-        "serif": str(ASSETS_DIR / "NotoSerif-Regular.ttf"),
-    }
-
     available: Dict[str, str] = {}
     missing: List[str] = []
 
-    for key, font_path in fonts.items():
-        path_obj = Path(font_path)
-        try:
-            if path_obj.exists() and path_obj.stat().st_size > 0:
-                available[key] = str(path_obj)
+    downloaded_roles: List[str] = []
+
+    def _attempt_download(role: str) -> None:
+        existing = any(
+            (ASSETS_DIR / candidate).exists() and (ASSETS_DIR / candidate).stat().st_size > 0
+            for candidate in FONT_CANDIDATES[role]
+        )
+        if existing:
+            return
+
+        for url in FONT_DOWNLOADS.get(role, ()):  # pragma: no branch - finite loop
+            filename = url.rsplit("/", 1)[-1]
+            destination = ASSETS_DIR / filename
+            if destination.exists() and destination.stat().st_size > 0:
+                break
+            try:
+                with contextlib.closing(urlopen(url, timeout=15)) as response:
+                    data = response.read()
+            except Exception:
+                continue
+            if not data or len(data) < 1024:
+                continue
+            try:
+                destination.write_bytes(data)
+            except OSError:
+                continue
             else:
-                missing.append(key)
-        except OSError:
-            missing.append(key)
+                downloaded_roles.append(role)
+                break
+
+    for role in FONT_CANDIDATES:
+        _attempt_download(role)
+
+    if downloaded_roles:
+        st.info(
+            "Downloaded font support for: "
+            + ", ".join(sorted(set(downloaded_roles)))
+            + "."
+        )
+
+    for role, candidates in FONT_CANDIDATES.items():
+        found_path: str | None = None
+        for directory in FONT_SEARCH_PATHS:
+            try:
+                if not directory.exists():
+                    continue
+            except OSError:
+                continue
+            for candidate in candidates:
+                candidate_path = directory / candidate
+                try:
+                    if candidate_path.exists() and candidate_path.stat().st_size > 0:
+                        found_path = str(candidate_path)
+                        break
+                except OSError:
+                    continue
+            if found_path:
+                break
+        if found_path:
+            available[role] = found_path
+        else:
+            missing.append(role)
 
     if missing:
-        # Prefer a gentle warning instead of an exception so PDF generation can
-        # continue with fallback fonts.
         st.warning(
-            "Custom Noto fonts are unavailable for: "
+            "Unicode-capable fonts not found for: "
             + ", ".join(sorted(missing))
-            + ". Using built-in PDF fonts instead."
+            + ". The PDF will fall back to limited built-in fonts; non-Latin text may not render correctly."
         )
 
     return available
@@ -215,17 +312,72 @@ def _write_story_content(pdf: StoryPDF, story: Dict[str, Any], params: Dict[str,
         pdf.multi_cell(0, 6, meta)
     pdf.ln(4)
 
-    pdf.set_font(pdf.serif_family, size=12)
+    summary = story.get("summary")
+    if summary:
+        pdf.set_font(pdf.serif_family, size=12)
+        pdf.set_text_color(70, 70, 70)
+        pdf.multi_cell(0, 7, summary)
+        pdf.ln(3)
+
+    reading_sections = story.get("reading_sections") or []
+    if reading_sections:
+        pdf.set_font(pdf.sans_family, size=14)
+        pdf.set_text_color(30, 30, 30)
+        pdf.multi_cell(0, 8, "Reading Support")
+        pdf.ln(1)
+
     pdf.set_text_color(0, 0, 0)
+    pdf.set_font(pdf.serif_family, size=12)
 
     line_height = 7
-    for paragraph in story.get("body", "").split("\n"):
-        cleaned = paragraph.strip()
-        if not cleaned:
-            pdf.ln(line_height / 2)
-            continue
-        pdf.multi_cell(0, line_height, cleaned)
+    for section in reading_sections:
+        original = section.get("original", "").strip()
+        phonetics = section.get("phonetics", "").strip()
+        translation = section.get("translation", "").strip()
+        if original:
+            pdf.multi_cell(0, line_height, original)
+        if phonetics:
+            pdf.set_font(pdf.sans_family, size=11)
+            pdf.set_text_color(90, 90, 90)
+            pdf.multi_cell(0, line_height, phonetics)
+            pdf.set_font(pdf.serif_family, size=12)
+            pdf.set_text_color(0, 0, 0)
+        if translation:
+            pdf.set_font(pdf.sans_family, size=11)
+            pdf.set_text_color(40, 40, 40)
+            pdf.multi_cell(0, line_height, translation)
+            pdf.set_font(pdf.serif_family, size=12)
+            pdf.set_text_color(0, 0, 0)
+        pdf.ln(2)
+
+    if not reading_sections:
+        body_text = story.get("body", "")
+        if body_text:
+            for paragraph in body_text.split("\n"):
+                cleaned = paragraph.strip()
+                if not cleaned:
+                    pdf.ln(line_height / 2)
+                    continue
+                pdf.multi_cell(0, line_height, cleaned)
+                pdf.ln(1)
+
+    full_translation = story.get("translation")
+    if full_translation:
         pdf.ln(1)
+        pdf.set_font(pdf.sans_family, size=14)
+        pdf.multi_cell(0, 8, "Full Story Translation")
+        pdf.ln(1)
+        pdf.set_font(pdf.sans_family, size=11)
+        pdf.set_text_color(40, 40, 40)
+        for paragraph in full_translation.split("\n"):
+            cleaned = paragraph.strip()
+            if not cleaned:
+                pdf.ln(line_height / 2)
+                continue
+            pdf.multi_cell(0, line_height, cleaned)
+            pdf.ln(1)
+        pdf.set_font(pdf.serif_family, size=12)
+        pdf.set_text_color(0, 0, 0)
 
     glossary = story.get("glossary") or []
     if params.get("include_glossary") and glossary:
@@ -240,6 +392,39 @@ def _write_story_content(pdf: StoryPDF, story: Dict[str, Any], params: Dict[str,
             if not term or not definition:
                 continue
             pdf.multi_cell(0, line_height, f"• {term}: {definition}")
+        pdf.ln(2)
+
+    grammar_notes = story.get("grammar_notes") or []
+    if grammar_notes:
+        pdf.ln(2)
+        pdf.set_font(pdf.sans_family, size=14)
+        pdf.multi_cell(0, 8, "Grammar Notes")
+        pdf.ln(1)
+        pdf.set_font(pdf.serif_family, size=12)
+        for note in grammar_notes:
+            pdf.multi_cell(0, line_height, f"• {note}")
+        pdf.ln(2)
+
+    practice_ideas = story.get("practice_ideas") or []
+    if practice_ideas:
+        pdf.ln(1)
+        pdf.set_font(pdf.sans_family, size=14)
+        pdf.multi_cell(0, 8, "Practice Ideas")
+        pdf.ln(1)
+        pdf.set_font(pdf.serif_family, size=12)
+        for idea in practice_ideas:
+            pdf.multi_cell(0, line_height, f"• {idea}")
+        pdf.ln(2)
+
+    extra_notes = story.get("extra_notes") or []
+    if extra_notes:
+        pdf.ln(1)
+        pdf.set_font(pdf.sans_family, size=14)
+        pdf.multi_cell(0, 8, "Strategy & Culture Notes")
+        pdf.ln(1)
+        pdf.set_font(pdf.serif_family, size=12)
+        for note in extra_notes:
+            pdf.multi_cell(0, line_height, f"• {note}")
         pdf.ln(2)
 
 


### PR DESCRIPTION
## Summary
- expand the graded reader prompt guidance so medium/long stories target fuller pages with richer paragraph counts
- raise the dynamic token budgets and retry heuristics to reduce truncated JSON responses from the model
- automatically download Unicode-capable Noto fonts (with UI messaging) so PDFs render CJK text and document the behavior

## Testing
- python -m compileall utils streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68db965c54d083328437e21a15042938